### PR TITLE
faction icons changelings

### DIFF
--- a/Content.Client/Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Client/Goobstation/Changeling/ChangelingSystem.cs
@@ -1,16 +1,21 @@
 using Content.Client.Alerts;
 using Content.Client.UserInterface.Systems.Alerts.Controls;
 using Content.Shared.Changeling;
+using Content.Shared.StatusIcon.Components;
+using Robust.Shared.Prototypes;
 
 namespace Content.Client.Changeling;
 
 public sealed partial class ChangelingSystem : EntitySystem
 {
+
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<ChangelingComponent, UpdateAlertSpriteEvent>(OnUpdateAlert);
+        SubscribeLocalEvent<ChangelingComponent, GetStatusIconsEvent>(GetChanglingIcon);
     }
 
     private void OnUpdateAlert(EntityUid uid, ChangelingComponent comp, ref UpdateAlertSpriteEvent args)
@@ -21,5 +26,12 @@ public sealed partial class ChangelingSystem : EntitySystem
         var chemicalsNormalised = (int) (comp.Chemicals / comp.MaxChemicals * 16); // hardcoded because uhh umm
         var sprite = args.SpriteViewEnt.Comp;
         sprite.LayerSetState(AlertVisualLayers.Base, $"{chemicalsNormalised}");
+    }
+
+        private void GetChanglingIcon(Entity<ChangelingComponent> ent, ref GetStatusIconsEvent args)
+    {
+
+        if (_prototype.TryIndex(ent.Comp.StatusIcon, out var iconPrototype))
+            args.StatusIcons.Add(iconPrototype);
     }
 }

--- a/Content.Shared/Goobstation/Changeling/ChangelingComponent.cs
+++ b/Content.Shared/Goobstation/Changeling/ChangelingComponent.cs
@@ -1,8 +1,11 @@
 using Content.Shared.Humanoid;
+using Content.Shared.StatusIcon;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+
+
 
 namespace Content.Shared.Changeling;
 
@@ -123,6 +126,12 @@ public sealed partial class ChangelingComponent : Component
     public TransformData? SelectedForm;
 
     #endregion
+    /// <summary>
+    /// The status icon corresponding to the Changlings.
+    /// </summary>
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public ProtoId<StatusIconPrototype> StatusIcon { get; set; } = "ChangelingFaction";
 }
 
 [DataDefinition]
@@ -156,4 +165,7 @@ public partial struct TransformData
         => one.Name == two.Name && one.Fingerprint == two.Fingerprint && one.DNA == two.DNA;
     public static bool operator !=(TransformData one, TransformData two)
         => !(one.Name == two.Name && one.Fingerprint == two.Fingerprint && one.DNA == two.DNA);
+
+
+
 }

--- a/Resources/Prototypes/Goobstation/Changeling/StatusIcon/antag.yml
+++ b/Resources/Prototypes/Goobstation/Changeling/StatusIcon/antag.yml
@@ -1,0 +1,10 @@
+- type: statusIcon
+  id: ChangelingFaction
+  priority: 11
+  showTo:
+    components:
+      - ShowAntagIcons
+      - Changeling
+  icon:
+    sprite: /Textures/Interface/Misc/job_icons.rsi
+    state: Geneticist


### PR DESCRIPTION
adds icons to the changelings
all code pretty mutch copied from revs.
makes it so atlest aghost can see changlings

shud probably be changed so the lings can only know other lings if they have hivemind.

![image](https://github.com/whateverusername0/Goob-Station/assets/2734131/ce2db006-c2f6-42ba-a768-ac7a30ef848a)
![image](https://github.com/whateverusername0/Goob-Station/assets/2734131/652a6691-6c3f-4fa1-b513-64a31c06ddec)

