### PR TITLE
Ling Bloodsystem

### DIFF
--- a/Content.Server/Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/Goobstation/Changeling/ChangelingSystem.cs
@@ -57,6 +57,7 @@ using System.Numerics;
 using Content.Shared.Camera;
 using Robust.Shared.Timing;
 using Content.Shared.Gravity;
+using Content.Server.Body.Components;
 using Content.Shared.Damage.Components;
 using Content.Server.Gravity;
 
@@ -471,6 +472,7 @@ public sealed partial class ChangelingSystem : EntitySystem
                 RemComp<StoreComponent>(newUid.Value);
                 EntityManager.AddComponent(newUid.Value, storeCompCopy);
             }
+            ChangeChangelingBloodtype(uid,newEnt);
         }
 
         // exceptional comps check
@@ -534,6 +536,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         RemComp<HungerComponent>(uid);
         RemComp<ThirstComponent>(uid);
         EnsureComp<ZombieImmuneComponent>(uid);
+        ChangeChangelingBloodtype(uid,uid);
 
         // add actions
         foreach (var actionId in comp.BaseChangelingActions)
@@ -845,6 +848,32 @@ public sealed partial class ChangelingSystem : EntitySystem
         }
 
         PlayMeatySound(uid, comp);
+    }
+    public void ChangeChangelingBloodtype(EntityUid uid,EntityUid newUid)
+    {
+        if(newUid==null)
+            return;
+        if(!HasComp<BloodstreamComponent>(newUid))
+            return;
+
+        if (TryComp<BloodstreamComponent>(newUid, out var stream))
+        {
+            var  bloodtype = stream.BloodReagent;
+            switch((String)stream.BloodReagent)
+            {
+                case "Blood": bloodtype = "changelingBlood";                //Human Dwarf Moth  Reptile
+                    break;
+                case "Slime": bloodtype = "changelingSlime";                //Slime
+                    break;
+                case "Sap": bloodtype = "changelingSap";                    //Diona
+                    break;
+                case  "CopperBlood": bloodtype = "changelingCopperBlood";   //Aracnid
+                    break;
+                case "AmmoniaBlood": bloodtype = "changelingAmmoniaBlood";  //Vox
+                    break;
+            }
+            _blood.ChangeBloodReagent(newUid, bloodtype);
+        }
     }
 
     #endregion

--- a/Resources/Prototypes/Goobstation/Changeling/Reagents/Changeling Blood.yml
+++ b/Resources/Prototypes/Goobstation/Changeling/Reagents/Changeling Blood.yml
@@ -1,0 +1,216 @@
+#Reagents
+- type: reagent
+  parent: Blood
+  id: changelingBlood
+
+- type: reagent
+  id: changelingSlime
+  parent: Slime
+
+- type: reagent
+  id: changelingSap
+  parent: Sap
+
+- type: reagent
+  parent: CopperBlood
+  id: changelingCopperBlood
+
+- type: reagent
+  parent: AmmoniaBlood
+  id: changelingAmmoniaBlood
+
+# Ractions
+- type: reaction
+  id: changelingBloodBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    changelingBlood:
+      amount: 5
+  products:
+    Water: 11
+    Iron: 0.5
+    Sugar: 2
+    CarbonDioxide: 3
+    Protein: 4
+  effects:
+    - !type:CreateEntityReactionEffect
+      entity: FleshKudzu
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 2
+      intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
+      intensitySlope: 4
+      maxTotalIntensity: 1
+
+- type: reaction
+  id: changelingSlimeBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    changelingSlime:
+      amount: 5
+  products:
+    Water: 4
+    Nitrogen: 1
+  effects:
+    - !type:CreateEntityReactionEffect
+      entity: FleshKudzu
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 2
+      intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
+      intensitySlope: 4
+      maxTotalIntensity: 1
+
+- type: reaction
+  id: changelingSapBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    changelingSap:
+      amount: 5
+  products:
+    Water: 9
+    Sugar: 1
+  effects:
+    - !type:CreateEntityReactionEffect
+      entity: FleshKudzu
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 2
+      intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
+      intensitySlope: 4
+      maxTotalIntensity: 1
+
+- type: reaction
+  id: changelingCopperBloodBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    changelingCopperBlood:
+      amount: 5
+  products:
+    Water: 11
+    Copper: 0.5
+    Sugar: 2
+    CarbonDioxide: 3
+    Protein: 4
+  effects:
+    - !type:CreateEntityReactionEffect
+      entity: FleshKudzu
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 2
+      intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
+      intensitySlope: 4
+      maxTotalIntensity: 1
+
+- type: reaction
+  id: changelingAmmoniaBloodBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    changelingAmmoniaBlood:
+      amount: 5
+  products:
+    Water: 11
+    Iron: 0.5
+    Sugar: 2
+    CarbonDioxide: 3
+    Protein: 4
+  effects:
+    - !type:CreateEntityReactionEffect
+      entity: FleshKudzu
+    - !type:ExplosionReactionEffect
+      explosionType: Default
+      maxIntensity: 2
+      intensityPerUnit: 0.5 # 50+50 reagent for maximum explosion
+      intensitySlope: 4
+      maxTotalIntensity: 1
+
+- type: reaction  #prevents having 2 Blood in one beaker
+  id: changelingBloodAndBlood
+  #sound: null # removing sound diddnt work
+  source: true
+  reactants:
+    Blood:
+      amount: 1
+    changelingBlood:
+      amount: 1
+  products:
+    changelingBlood: 2
+
+- type: reaction  #prevents having 2 Blood in one beaker
+  id: changelingSlimeAndSlime
+  #sound: null # removing sound diddnt work
+  source: true
+  reactants:
+    Slime:
+      amount: 1
+    changelingSlime:
+      amount: 1
+  products:
+    changelingSlime: 2
+- type: reaction  #prevents having 2 Blood in one beaker
+  id: changelingSapdAndSap
+  #sound: null # removing sound diddnt work
+  source: true
+  reactants:
+    Sap:
+      amount: 1
+    changelingSap:
+      amount: 1
+  products:
+    changelingSap: 2
+
+- type: reaction  #prevents having 2 Blood in one beaker
+  id: changelingCopperBloodAndCopperBlood
+  #sound: null # removing sound diddnt work
+  source: true
+  reactants:
+    CopperBlood:
+      amount: 1
+    changelingCopperBlood:
+      amount: 1
+  products:
+    changelingCopperBlood: 2
+
+- type: reaction  #prevents having 2 Blood in one beaker
+  id: cchangelingAmmoniaBlooddAndAmmoniaBlood
+  #sound: null # removing sound diddnt work
+  source: true
+  reactants:
+    AmmoniaBlood:
+      amount: 1
+    changelingAmmoniaBlood:
+      amount: 1
+  products:
+    changelingAmmoniaBlood: 2
+
+#bottles whit blood for Testing purposes
+- type: entity
+  id: ChangelingBloodBottle
+  name: ChangelingBlood bottle
+  parent: BaseChemistryBottleFilled
+  components:
+    - type: SolutionContainerManager
+      solutions:
+        drink:
+          maxVol: 30
+          reagents:
+            - ReagentId: changelingBlood
+              Quantity: 10
+            - ReagentId: changelingSlime
+              Quantity: 5
+            - ReagentId: changelingSap
+              Quantity: 5
+            - ReagentId: changelingCopperBlood
+              Quantity: 5
+            - ReagentId: changelingAmmoniaBlood
+              Quantity: 5


### PR DESCRIPTION
added new reagents for Ling Blood

if mixed whit parent blood it all becoms ling blood. this is to prevent there from being blood + blood in a beaker 
Can test ling blood in a centrifuge will make same product as parents blood + explode + spawn meatkudzu

possible exploits
 will not mix whit parents blood in crostastis beaker
 will not combine if parents blood is used in recipie example: demnon blood drink or space Glue
tryed to remove the boubling sound when changling blood and parent blood mixxed but this gave me errors.