### PR TITLE
Small refactor to PKA mod system

### DIFF
--- a/Content.Server/_Lavaland/Weather/LavalandStormedMapComponent.cs
+++ b/Content.Server/_Lavaland/Weather/LavalandStormedMapComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class LavalandStormedMapComponent : Component
     public float Duration;
 
     [DataField]
-    public float NextDamage = 1f;
+    public float NextDamage = 10f;
 
     [DataField]
     public float DamageAccumulator;

--- a/Content.Server/_Lavaland/Weather/LavalandStormedMapComponent.cs
+++ b/Content.Server/_Lavaland/Weather/LavalandStormedMapComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class LavalandStormedMapComponent : Component
     public float Duration;
 
     [DataField]
-    public float NextDamage = 10f;
+    public float NextDamage = 1f;
 
     [DataField]
     public float DamageAccumulator;

--- a/Content.Shared/_Lavaland/CCVar/CCVars.Lavaland.cs
+++ b/Content.Shared/_Lavaland/CCVar/CCVars.Lavaland.cs
@@ -10,4 +10,7 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<bool> LavalandEnabled =
         CVarDef.Create("lavaland.enabled", true, CVar.SERVERONLY);
+
+    public static readonly CVarDef<bool> AllowDuplicatePkaModules =
+        CVarDef.Create("modkit.dupes.enabled", true, CVar.REPLICATED | CVar.SERVER);
 }

--- a/Content.Shared/_Lavaland/Weapons/Ranged/Upgrades/Components/GunComponentUpdateComponent.cs
+++ b/Content.Shared/_Lavaland/Weapons/Ranged/Upgrades/Components/GunComponentUpdateComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared._Lavaland.Weapons.Ranged.Upgrades.Components;
 
 [RegisterComponent, NetworkedComponent, Access(typeof(GunUpgradeSystem))]
-public sealed partial class GunComponentUpgrateComponent : Component
+public sealed partial class GunComponentUpgradeComponent : Component
 {
     [DataField]
     public ComponentRegistry Components = new();

--- a/Content.Shared/_Lavaland/Weapons/Ranged/Upgrades/Components/GunUpgradeComponent.cs
+++ b/Content.Shared/_Lavaland/Weapons/Ranged/Upgrades/Components/GunUpgradeComponent.cs
@@ -12,4 +12,7 @@ public sealed partial class GunUpgradeComponent : Component
 
     [DataField]
     public LocId ExamineText;
+
+    [DataField]
+    public int CapacityCost = 30; // By default drains 30% of the capacity.
 }

--- a/Content.Shared/_Lavaland/Weapons/Ranged/Upgrades/Components/UpgradeableGunComponent.cs
+++ b/Content.Shared/_Lavaland/Weapons/Ranged/Upgrades/Components/UpgradeableGunComponent.cs
@@ -14,8 +14,5 @@ public sealed partial class UpgradeableGunComponent : Component
     public EntityWhitelist Whitelist = new();
 
     [DataField]
-    public SoundSpecifier? InsertSound = new SoundPathSpecifier("/Audio/Effects/thunk.ogg");
-
-    [DataField]
     public int MaxUpgradeCount = 3;
 }

--- a/Content.Shared/_Lavaland/Weapons/Ranged/Upgrades/Components/UpgradeableGunComponent.cs
+++ b/Content.Shared/_Lavaland/Weapons/Ranged/Upgrades/Components/UpgradeableGunComponent.cs
@@ -14,5 +14,8 @@ public sealed partial class UpgradeableGunComponent : Component
     public EntityWhitelist Whitelist = new();
 
     [DataField]
-    public int MaxUpgradeCount = 3;
+    public int? MaxUpgradeCount;
+
+    [DataField]
+    public int MaxUpgradeCapacity = 100;
 }

--- a/Resources/Locale/en-US/_Lavaland/prototypes/Entities/Objects/Specific/gun_upgrades.ftl
+++ b/Resources/Locale/en-US/_Lavaland/prototypes/Entities/Objects/Specific/gun_upgrades.ftl
@@ -1,5 +1,5 @@
 upgradeable-gun-popup-upgrade-limit = Maximum capacity for upgrades exceeded!
-
+upgradeable-gun-slot-name = Attachment slot {$value}
 gun-upgrade-examine-text-damage = Contains a [color=#ec9b2d][bold]damage[/bold][/color] upgrade.
 gun-upgrade-examine-text-range = Contains a [color=#2decec][bold]range[/bold][/color] upgrade.
 gun-upgrade-examine-text-reload = Contains a [color=#bbf134][bold]fire rate.[/bold][/color] upgrade.

--- a/Resources/Locale/en-US/_Lavaland/prototypes/Entities/Objects/Specific/gun_upgrades.ftl
+++ b/Resources/Locale/en-US/_Lavaland/prototypes/Entities/Objects/Specific/gun_upgrades.ftl
@@ -1,7 +1,9 @@
 upgradeable-gun-popup-upgrade-limit = Maximum capacity for upgrades exceeded!
 upgradeable-gun-slot-name = Attachment slot {$value}
+upgradeable-gun-total-remaining-capacity = Total remaining capacity: {$value}
 gun-upgrade-examine-text-damage = Contains a [color=#ec9b2d][bold]damage[/bold][/color] upgrade.
 gun-upgrade-examine-text-range = Contains a [color=#2decec][bold]range[/bold][/color] upgrade.
 gun-upgrade-examine-text-reload = Contains a [color=#bbf134][bold]fire rate.[/bold][/color] upgrade.
 gun-upgrade-examine-text-light = Contains a [color=#bbf134][bold]light.[/bold][/color] upgrade.
 gun-upgrade-examine-text-vampirism = Contains a [color=crimson][bold]vampirism.[/bold][/color] upgrade.
+gun-upgrade-examine-text-capacity-cost = Requires {$value} capacity.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -11,13 +11,10 @@
     shape:
     - 0,0,2,1
   # Lavaland Change start
-  - type: UpgradeableGun 
+  - type: UpgradeableGun
     whitelist:
       tags:
       - PKAUpgrade
-  - type: ContainerContainer
-    containers:
-      upgrades: !type:Container
   #- type: GunWieldBonus
   #  minAngle: -43
   #  maxAngle: -43

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
@@ -31,6 +31,7 @@
     - state: overlay-3
       color: "#eb4c13"
   - type: GunUpgrade
+    capacityCost: 40
     tags: [ GunUpgradeDamage ]
     examineText: gun-upgrade-examine-text-damage
   - type: GunUpgradeDamage
@@ -75,6 +76,7 @@
       color: "#9bf134"
   - type: GunUpgrade
     tags: [ GunUpgradeReloadSpeed ]
+    capacityCost: 20
     examineText: gun-upgrade-examine-text-reload
   - type: GunUpgradeFireRate
     coefficient: 1.5
@@ -96,7 +98,8 @@
   - type: GunUpgrade
     tags: [ GunUpgradeReloadSpeed ]
     examineText: gun-upgrade-examine-text-light
-  - type: GunComponentUpgrate
+    capacityCost: 10
+  - type: GunComponentUpgrade
     components:
     - type: UnpoweredFlashlight
     - type: PointLight


### PR DESCRIPTION
GAMING

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Mocho
- tweak: Added a CVAR that lets server operators decide if players should be able to stack PKA modules of the same type, due to the lack of balancing to lavaland mob health atm.
- tweak: PKA modules now have a mod capacity, rather than a hard cap of 3, certain modules will drain more capacity than others.
- fix: Now you can eject PKA modules properly.
